### PR TITLE
override root node from cli

### DIFF
--- a/kol/scripts/get_urdf.py
+++ b/kol/scripts/get_urdf.py
@@ -28,7 +28,7 @@ def main(args: Sequence[str] | None = None) -> None:
     parser.add_argument("--suffix-to-joint-velocity", type=str, nargs="+", help="The suffix to joint velocity mapping")
     parser.add_argument("--disable-mimics", action="store_true", help="Disable the mimic joints")
     parser.add_argument("--mesh-ext", type=str, default="stl", choices=get_args(MeshExt), help="The mesh file format")
-    parser.add_argument("--override-center", type=str, default=None, help="Override central link")
+    parser.add_argument("--override-central-node", type=str, default=None, help="Override central link")
     parsed_args = parser.parse_args(args)
 
     configure_logging(level=logging.DEBUG if parsed_args.debug else logging.INFO)
@@ -64,7 +64,7 @@ def main(args: Sequence[str] | None = None) -> None:
         suffix_to_joint_velocity=suffix_to_joint_velocity,
         disable_mimics=parsed_args.disable_mimics,
         mesh_ext=parsed_args.mesh_ext,
-        override_center=parsed_args.override_center,
+        override_central_node=parsed_args.override_central_node,
     ).save_urdf()
 
 

--- a/kol/scripts/get_urdf.py
+++ b/kol/scripts/get_urdf.py
@@ -28,6 +28,7 @@ def main(args: Sequence[str] | None = None) -> None:
     parser.add_argument("--suffix-to-joint-velocity", type=str, nargs="+", help="The suffix to joint velocity mapping")
     parser.add_argument("--disable-mimics", action="store_true", help="Disable the mimic joints")
     parser.add_argument("--mesh-ext", type=str, default="stl", choices=get_args(MeshExt), help="The mesh file format")
+    parser.add_argument("--override-center", type=str, default=None, help="Override central link")
     parsed_args = parser.parse_args(args)
 
     configure_logging(level=logging.DEBUG if parsed_args.debug else logging.INFO)
@@ -63,6 +64,7 @@ def main(args: Sequence[str] | None = None) -> None:
         suffix_to_joint_velocity=suffix_to_joint_velocity,
         disable_mimics=parsed_args.disable_mimics,
         mesh_ext=parsed_args.mesh_ext,
+        override_center=parsed_args.override_center,
     ).save_urdf()
 
 


### PR DESCRIPTION
original urdf with no override:  
'kol urdf https://cad.onshape.com/documents/4d080ffa7583ef10f38b5108/w/cfa27ea29bfa8920dc000bf0/e/69e516cecb4bb0374594d77a'
<img width="978" alt="Screenshot 2024-05-30 at 4 11 31 PM" src="https://github.com/kscalelabs/onshape/assets/110312634/2d86c352-be82-4b23-b5ad-d65b457f38c1">


Looks the same, but link orders are different in output urdf now.
To override which link will end up first in the urdf add the argument and the new center link - kol urdf https://cad.onshape.com/documents/4d080ffa7583ef10f38b5108/w/cfa27ea29bfa8920dc000bf0/e/69e516cecb4bb0374594d77a --override-central-node "part_1_1"
<img width="924" alt="Screenshot 2024-05-30 at 3 38 27 PM" src="https://github.com/kscalelabs/onshape/assets/110312634/1a0c235a-a20a-44bb-9886-f9e3b9a23e96">