### PR TITLE
Script for cleaning up all meshes not in urdf.

### DIFF
--- a/kol/scripts/cleanup_mesh_dir.py
+++ b/kol/scripts/cleanup_mesh_dir.py
@@ -1,0 +1,44 @@
+"""Removes all meshes not mentioned in a urdf from the ./meshes directory."""
+
+import argparse
+import logging
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Sequence
+
+logger = logging.getLogger(__name__)
+
+
+def main(args: Sequence[str] | None = None) -> None:
+    logging.basicConfig(level=logging.INFO)
+
+    parser = argparse.ArgumentParser(description="Cleanup meshes directory")
+    parser.add_argument("filepath", type=str, help="The path to the urdf file")
+    parsed_args = parser.parse_args(args)
+
+    filepath = Path(parsed_args.filepath)
+    urdf_tree = ET.parse(filepath)
+    deleted = 0
+    logger.info("Cleaning up obsolete meshes.")
+    mesh_dir = filepath.parent / "meshes"
+
+    all_links = urdf_tree.findall(".//link")
+    all_stl_names = []
+    for link in all_links:
+        visual = link.find("visual")
+        if visual is not None:
+            mesh = visual.find("geometry/mesh")
+            if mesh is not None:
+                all_stl_names.append(mesh.attrib["filename"])
+    for link in all_links:
+        collision = link.find("collision")
+        if collision is not None:
+            mesh = collision.find("geometry/mesh")
+            if mesh is not None:
+                all_stl_names.append(mesh.attrib["filename"])
+    all_stl_names = [name.split("/")[-1] for name in all_stl_names]
+    for mesh_file in mesh_dir.glob("*.stl"):
+        if mesh_file.name not in all_stl_names:
+            mesh_file.unlink()
+            deleted += 1
+    logger.info("Cleaned up %d meshes.", deleted)

--- a/kol/scripts/cli.py
+++ b/kol/scripts/cli.py
@@ -4,6 +4,7 @@ import argparse
 from typing import Sequence
 
 from kol.scripts import (
+    cleanup_mesh_dir,
     get_mjcf,
     get_urdf,
     merge_fixed_joints,
@@ -19,7 +20,17 @@ def main(args: Sequence[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="K-Scale OnShape Library", add_help=False)
     parser.add_argument(
         "subcommand",
-        choices=["urdf", "mjcf", "pybullet", "mujoco", "stl", "simplify", "merge-fixed-joints", "simplify-all"],
+        choices=[
+            "urdf",
+            "mjcf",
+            "pybullet",
+            "mujoco",
+            "stl",
+            "simplify",
+            "merge-fixed-joints",
+            "simplify-all",
+            "cleanup-mesh-dir",
+        ],
         help="The subcommand to run",
     )
     parsed_args, remaining_args = parser.parse_known_args(args)
@@ -41,6 +52,8 @@ def main(args: Sequence[str] | None = None) -> None:
             merge_fixed_joints.main(remaining_args)
         case "simplify-all":
             simplify_meshes.main(remaining_args)
+        case "cleanup-mesh-dir":
+            cleanup_mesh_dir.main(remaining_args)
         case _:
             raise ValueError(f"Unknown subcommand: {parsed_args.subcommand}")
 

--- a/kol/scripts/merge_fixed_joints.py
+++ b/kol/scripts/merge_fixed_joints.py
@@ -11,14 +11,10 @@ def main(args: Sequence[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Merge fixed joints in a urdf.")
     parser.add_argument("filepath", type=str, help="The path to the urdf file")
     parser.add_argument("--scaling", type=float, default=1, help="The scaling factor for each fused mesh")
-    parser.add_argument(
-        "--cleanup_fused_meshes", action="store_true", help="Whether to remove the fused meshes after merging"
-    )
     parsed_args = parser.parse_args(args)
 
     urdf_path = Path(parsed_args.filepath)
     get_merged_urdf(
         urdf_path=urdf_path,
         scaling=parsed_args.scaling,
-        cleanup_fused_meshes=parsed_args.cleanup_fused_meshes,
     )


### PR DESCRIPTION
To reproduce with test urdf
```
kol urdf https://cad.onshape.com/documents/f7270a016ee61de0fc66644e/w/bc52ccf2c1583b6f65334bed/e/aa39ae5ecba3eac8dcb62f9d 
&& kol merge-fixed-joints robot/assembly_1.urdf 
&& kol simplify-all robot/assembly_1_merged.urdf 
&& kol cleanup-mesh-dir robot/assembly_1_merged_simplified.urdf
```