### PR TITLE
retry on 400

### DIFF
--- a/onshape/onshape/api.py
+++ b/onshape/onshape/api.py
@@ -21,7 +21,7 @@ from onshape.onshape.schema.part import PartDynamics, PartMetadata, ThumbnailInf
 
 logger = logging.getLogger(__name__)
 
-RETRY_STATUS_CODES = (429, 500, 502, 503, 504)
+RETRY_STATUS_CODES = (400, 429, 500, 502, 503, 504)
 
 
 def escape_url(s: str) -> str:


### PR DESCRIPTION
Occasionally seeing things like this:

```
ERROR  2025-05-03 22:58:51 [onshape.onshape.client] Got response 400 for /modelexport, details: {
  "message" : "An illegal argument was provided, check your request.",
  "status" : 400,
  "code" : 0,
  "moreInfoUrl" : ""
}
```

which appears to be transient