### PR TITLE
Support for Composite parts

### DIFF
--- a/onshape/onshape/schema/assembly.py
+++ b/onshape/onshape/schema/assembly.py
@@ -259,6 +259,7 @@ class AssemblyMetadata(BaseModel):
 class PartBodyType(str, Enum):
     sheet = "sheet"
     solid = "solid"
+    composite = "composite"
 
 
 class Part(BaseModel):


### PR DESCRIPTION
Previous Pydantic schema only allowed "solid" (and/or "sheet"), which caused a ValidationError when parsing assemblies that contain composite parts.

Change:
- Extend `PartBodyType` to include `"composite"`

Rationale:
- Composite parts are first-class in Onshape assemblies; parsing should accept them.
- This change is additive/backwards-compatible as existing behavior for "solid" is unchanged.

Verification:
- Locally verified "onshape run" succeeds on the previously failing assembly (https://cad.onshape.com/documents/cacc96f8a7850b951e7aa69a/v/0b68bc480ee9159c974e6336/e/a3debca6b790e5cda599c3ae).

Risk / Compatibility:
- Low risk as the change only widens accepted enum values.
- Callers that rely on bodyType can continue to filter as `{solid, composite}` if needed
